### PR TITLE
Update ModEntry.cs to use new mobile phone

### DIFF
--- a/MailboxMenu/ModEntry.cs
+++ b/MailboxMenu/ModEntry.cs
@@ -100,7 +100,7 @@ namespace MailboxMenu
 
         private void GameLoop_GameLaunched(object sender, StardewModdingAPI.Events.GameLaunchedEventArgs e)
         {
-            var phoneAPI = Helper.ModRegistry.GetApi<IMobilePhoneApi>("aedenthorn.MobilePhone");
+            var phoneAPI = Helper.ModRegistry.GetApi<IMobilePhoneApi>("JoXW.MobilePhone");
             if (phoneAPI != null)
             {
                 phoneAPI.AddApp("aedenthorn.MailboxMenu", "Mailbox", OpenMenu, Helper.ModContent.Load<Texture2D>(Path.Combine("assets", "icon.png")));


### PR DESCRIPTION
Hi, I was going to upload my 1.6 port of MailboxMenu when I saw you'd already created one, so here's a pull request instead! This pull request adds support for the ported mobile phone app. I believe the new app uses 48x48 icons instead of 64x64, so you'll need to replace the icon in assets with the attached image. Thanks!

![icon](https://github.com/kqrse/StardewValleyMods-aedenthorn/assets/146482804/d75ae6fa-8da5-4bf5-be03-df477c9ce7df)
